### PR TITLE
bump TF training version

### DIFF
--- a/training/max-image-segmenter-training-config.yaml
+++ b/training/max-image-segmenter-training-config.yaml
@@ -6,7 +6,7 @@ author:
       name: IBM CODAIT
 framework:
       name: tensorflow
-      version: '1.12'
+      version: '1.15'
       runtimes:
             name: python
             version: 3.6


### PR DESCRIPTION
WML no longer supports TF 1.12 for training.